### PR TITLE
Required 'rspec/matchers'.

### DIFF
--- a/lib/delegate_matcher/delegate_matcher.rb
+++ b/lib/delegate_matcher/delegate_matcher.rb
@@ -1,3 +1,5 @@
+require 'rspec/matchers'
+
 RSpec::Matchers.define(:delegate) do |method|
   match do |delegator|
     fail 'need to provide a "to"' unless delegate


### PR DESCRIPTION
I was getting the following error when trying to run the rails console:

<pre><samp>uninitialized constant RSpec::Matchers (NameError)
</samp></pre>


Adding the appropriate require fixed the issue.
